### PR TITLE
Improve support for non-posix pthread functions

### DIFF
--- a/lib/librumpuser/configure
+++ b/lib/librumpuser/configure
@@ -3073,7 +3073,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -3119,7 +3119,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -3143,7 +3143,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -3188,7 +3188,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -3212,7 +3212,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -3647,7 +3647,7 @@ done
 
 
 for ac_header in sys/param.h sys/sysctl.h sys/disk.h \
-	sys/disklabel.h sys/dkio.h sys/atomic.h paths.h
+	sys/disklabel.h sys/dkio.h sys/atomic.h paths.h pthread_np.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -4081,6 +4081,53 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_mutex_lock in -lpthread" >&5
+$as_echo_n "checking for pthread_mutex_lock in -lpthread... " >&6; }
+if ${ac_cv_lib_pthread_pthread_mutex_lock+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpthread  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_mutex_lock ();
+int
+main ()
+{
+return pthread_mutex_lock ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pthread_pthread_mutex_lock=yes
+else
+  ac_cv_lib_pthread_pthread_mutex_lock=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_mutex_lock" >&5
+$as_echo "$ac_cv_lib_pthread_pthread_mutex_lock" >&6; }
+if test "x$ac_cv_lib_pthread_pthread_mutex_lock" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBPTHREAD 1
+_ACEOF
+
+  LIBS="-lpthread $LIBS"
+
+else
+  as_fn_error $? "can't build without libpthread" "$LINENO" 5
+fi
+
 
 ac_fn_c_check_member "$LINENO" "struct sockaddr_in" "sin_len" "ac_cv_member_struct_sockaddr_in_sin_len" "#include <netinet/in.h>
 "
@@ -4094,8 +4141,82 @@ _ACEOF
 fi
 
 
+if test "x$ac_cv_header_pthread_np_h" = xyes; then :
+  ac_fn_c_check_func "$LINENO" "pthread_set_name_np" "ac_cv_func_pthread_set_name_np"
+if test "x$ac_cv_func_pthread_set_name_np" = xyes; then :
+
+$as_echo "#define pthread_setname_npx pthread_set_name_np" >>confdefs.h
+
+fi
+
+fi
+
 SAVE_CFLAGS="${CFLAGS}"
-CFLAGS="${SAVE_CFLAGS} -Werror"
+CFLAGS="${SAVE_CFLAGS} -Werror -Wimplicit-function-declaration"
+
+if test "x$ac_cv_func_pthread_set_name_np" != xyes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for two-argument pthread_setname_np()" >&5
+$as_echo_n "checking for two-argument pthread_setname_np()... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#define _GNU_SOURCE
+		  #include <pthread.h>
+int
+main ()
+{
+pthread_t pt;
+		  pthread_setname_np(pt, "x");
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		$as_echo "#define pthread_setname_npx pthread_setname_np" >>confdefs.h
+
+
+else
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for three-argument pthread_setname_np()" >&5
+$as_echo_n "checking for three-argument pthread_setname_np()... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#define _GNU_SOURCE
+		  #include <pthread.h>
+int
+main ()
+{
+pthread_t pt;
+		  pthread_setname_npx(pt, "X", (void *)0);
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		$as_echo "#define pthread_setname_npx(a, b) pthread_setname_np(a, b, NULL)" >>confdefs.h
+
+
+else
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+		$as_echo "#define pthread_setname_npx(a, b) /**/" >>confdefs.h
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
 
 for ac_header in sys/cdefs.h
 do :
@@ -4111,72 +4232,6 @@ fi
 done
 
 
-SAVE_LIBS="${LIBS}"
-LIBS="${LIBS} -lpthread"
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for two-argument pthread_setname_np()" >&5
-$as_echo_n "checking for two-argument pthread_setname_np()... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#define _GNU_SOURCE
-		  #include <pthread.h>
-int
-main ()
-{
-pthread_t pt;
-		pthread_setname_np(pt, "x");return 0;
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_PTHREAD_SETNAME2 1" >>confdefs.h
-
-
-else
-
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for three-argument pthread_setname_np()" >&5
-$as_echo_n "checking for three-argument pthread_setname_np()... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#define _GNU_SOURCE
-		  #include <pthread.h>
-int
-main ()
-{
-pthread_t pt;
-		pthread_setname_np(pt, "X", (void *)0);return 0;
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_PTHREAD_SETNAME3 1" >>confdefs.h
-
-
-else
-
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-LIBS="${SAVELIBS}"
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ioctl cmd being int" >&5
 $as_echo_n "checking for ioctl cmd being int... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -4188,7 +4243,6 @@ int
 main ()
 {
 
-		return 0;
   ;
   return 0;
 }

--- a/lib/librumpuser/configure.ac
+++ b/lib/librumpuser/configure.ac
@@ -20,7 +20,7 @@ AC_LANG([C])
 AC_SYS_LARGEFILE
 
 AC_CHECK_HEADERS([sys/param.h sys/sysctl.h sys/disk.h \
-	sys/disklabel.h sys/dkio.h sys/atomic.h paths.h])
+	sys/disklabel.h sys/dkio.h sys/atomic.h paths.h pthread_np.h])
 
 AC_CANONICAL_TARGET
 
@@ -44,59 +44,64 @@ AC_CHECK_LIB([rt], [clock_nanosleep],
 AC_CHECK_LIB([dl], [dlinfo],
 	AC_DEFINE([HAVE_DLINFO], 1, [dlinfo]),
 	AC_TRY_LINK_FUNC([dlinfo], AC_DEFINE([HAVE_DLINFO], 1, [dlinfo])))
+AC_CHECK_LIB([pthread], [pthread_mutex_lock], [],
+	[AC_MSG_ERROR([can't build without libpthread])])
 
 AC_CHECK_MEMBERS([struct sockaddr_in.sin_len],,,[#include <netinet/in.h>])
 
 dnl
 dnl pthread_setname() sillyness is a bit longer; we need the signature
 dnl
+AS_IF([test "x$ac_cv_header_pthread_np_h" = xyes],
+      [AC_CHECK_FUNC([pthread_set_name_np],
+                     [AC_DEFINE([pthread_setname_npx],
+                                [pthread_set_name_np],
+                                [Replacement for pthread_setname_np()])])])
+
 SAVE_CFLAGS="${CFLAGS}"
-CFLAGS="${SAVE_CFLAGS} -Werror"
+CFLAGS="${SAVE_CFLAGS} -Werror -Wimplicit-function-declaration"
 
-dnl check sys/cdefs.h creatively to process only with cc, not cpp
-dnl (sys/cdefs.h in at least in musl contains a #warning)
-AC_CHECK_HEADERS([sys/cdefs.h], [], [], [#include <sys/cdefs.h>])
-
-SAVE_LIBS="${LIBS}"
-LIBS="${LIBS} -lpthread"
-AC_MSG_CHECKING([for two-argument pthread_setname_np()])
+AS_IF([test "x$ac_cv_func_pthread_set_name_np" != xyes],
+      [AC_MSG_CHECKING([for two-argument pthread_setname_np()])
 AC_COMPILE_IFELSE(
 	[AC_LANG_PROGRAM(
 		[[#define _GNU_SOURCE
 		  #include <pthread.h>]],
-		[[pthread_t pt;]
-		[pthread_setname_np(pt, "x");return 0;]])
+		[[pthread_t pt;
+		  pthread_setname_np(pt, "x");]])
 	],[
 		AC_MSG_RESULT([yes])
-		AC_DEFINE(HAVE_PTHREAD_SETNAME2, [1],
-		    [Define to 1 if you have 2-arg pthread_setname_np()])
+		AC_DEFINE([pthread_setname_npx],
+			  [pthread_setname_np])
 	],[
 		AC_MSG_RESULT([no])
-])
 AC_MSG_CHECKING([for three-argument pthread_setname_np()])
 AC_COMPILE_IFELSE(
 	[AC_LANG_PROGRAM(
 		[[#define _GNU_SOURCE
 		  #include <pthread.h>]],
-		[[pthread_t pt;]
-		[pthread_setname_np(pt, "X", (void *)0);return 0;]])
+		[[pthread_t pt;
+		  pthread_setname_npx(pt, "X", (void *)0);]])
 	],[
 		AC_MSG_RESULT([yes])
-		AC_DEFINE(HAVE_PTHREAD_SETNAME3, [1],
-		    [Define to 1 if you have 3-arg pthread_setname_np()])
+		AC_DEFINE([pthread_setname_npx(a, b)],
+			  [pthread_setname_np(a, b, NULL)])
 	],[
 		AC_MSG_RESULT([no])
-])
-LIBS="${SAVELIBS}"
+		AC_DEFINE([pthread_setname_npx(a, b)],
+			  [])
+])])])
+
+dnl check sys/cdefs.h creatively to process only with cc, not cpp
+dnl (sys/cdefs.h in at least in musl contains a #warning)
+AC_CHECK_HEADERS([sys/cdefs.h], [], [], [#include <sys/cdefs.h>])
 
 AC_MSG_CHECKING([for ioctl cmd being int])
 AC_COMPILE_IFELSE(
 	[AC_LANG_PROGRAM(
 		[[#include <sys/ioctl.h>
 		  #include <unistd.h>
-		  int ioctl(int fd, int, ...);]],
-		[[]
-		[return 0;]])
+		  int ioctl(int fd, int, ...);]])
 	],[
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(HAVE_IOCTL_CMD_INT, [1],

--- a/lib/librumpuser/rumpuser_config.h.in
+++ b/lib/librumpuser/rumpuser_config.h.in
@@ -42,6 +42,9 @@
 /* Define to 1 if you have the `kqueue' function. */
 #undef HAVE_KQUEUE
 
+/* Define to 1 if you have the `pthread' library (-lpthread). */
+#undef HAVE_LIBPTHREAD
+
 /* Define to 1 if you have the `rt' library (-lrt). */
 #undef HAVE_LIBRT
 
@@ -57,11 +60,8 @@
 /* Define to 1 if you have the `posix_memalign' function. */
 #undef HAVE_POSIX_MEMALIGN
 
-/* Define to 1 if you have 2-arg pthread_setname_np() */
-#undef HAVE_PTHREAD_SETNAME2
-
-/* Define to 1 if you have 3-arg pthread_setname_np() */
-#undef HAVE_PTHREAD_SETNAME3
+/* Define to 1 if you have the <pthread_np.h> header file. */
+#undef HAVE_PTHREAD_NP_H
 
 /* Define to 1 if the system has the type `register_t'. */
 #undef HAVE_REGISTER_T
@@ -154,3 +154,6 @@
 
 /* Define for large files, on AIX-style hosts. */
 #undef _LARGE_FILES
+
+/* Replacement for pthread_setname_np() */
+#undef pthread_setname_npx

--- a/lib/librumpuser/rumpuser_port.h
+++ b/lib/librumpuser/rumpuser_port.h
@@ -25,10 +25,10 @@
 #define HAVE_GETSUBOPT 1
 #define HAVE_INTTYPES_H 1
 #define HAVE_KQUEUE 1
+#define HAVE_LIBPTHREAD 1
 #define HAVE_MEMORY_H 1
 #define HAVE_PATHS_H 1
 #define HAVE_POSIX_MEMALIGN 1
-#define HAVE_PTHREAD_SETNAME3 1
 #define HAVE_REGISTER_T 1
 #define HAVE_SETPROGNAME 1
 #define HAVE_STDINT_H 1
@@ -59,6 +59,7 @@
 #ifndef _DARWIN_USE_64_BIT_INODE
 # define _DARWIN_USE_64_BIT_INODE 1
 #endif
+#define pthread_setname_npx(a, b) pthread_setname_np(a, b, NULL)
 
 #else /* RUMPUSER_CONFIG */
 #include "rumpuser_config.h"

--- a/lib/librumpuser/rumpuser_pth.c
+++ b/lib/librumpuser/rumpuser_pth.c
@@ -47,6 +47,10 @@ __RCSID("$NetBSD: rumpuser_pth.c,v 1.45 2015/09/18 10:56:25 pooka Exp $");
 #include <stdint.h>
 #include <unistd.h>
 
+#if defined(HAVE_PTHREAD_NP_H)
+#include <pthread_np.h>
+#endif
+
 #include <rump/rumpuser.h>
 
 #include "rumpuser_int.h"
@@ -80,15 +84,9 @@ rumpuser_thread_create(void *(*f)(void *), void *arg, const char *thrname,
 		nanosleep(&ts, NULL);
 	}
 
-#if defined(HAVE_PTHREAD_SETNAME3)
 	if (rv == 0 && thrname) {
-		pthread_setname_np(*ptidp, thrname, NULL);
+		pthread_setname_npx(*ptidp, thrname);
 	}
-#elif defined(HAVE_PTHREAD_SETNAME2)
-	if (rv == 0 && thrname) {
-		pthread_setname_np(*ptidp, thrname);
-	}
-#endif
 
 	if (joinable) {
 		assert(ptcookie);


### PR DESCRIPTION
Fix issues on FreeBSD with the `pthread_setname_np()` function (see https://www.freelists.org/post/rumpkernel-users/Bug-in-srcnetbsd,5).

I've tested it on FreeBSD 11.0 (32 bit) and on ArchLinux (64 bit). Should be tested on NetBSD too and the content of `rumpuser_port.h` checked.

**NOTE**: You don't really need the `-Wimplicit-function-declaration` option to build on FreeBSD, as the presence of the `pthread_set_name_np()` function will make `configure` skip the 2/3 args checks on `pthread_setname_np()`. However, I kept it as it solves issues that would arise with old-yet-still-available versions of GCC on Linux (i.e., the 2 and the 3 args checks both successfully passed).